### PR TITLE
Added full path to adfind.exe

### DIFF
--- a/S0552 - AdFind/VFS/adf.bat
+++ b/S0552 - AdFind/VFS/adf.bat
@@ -1,10 +1,10 @@
-adfind.exe -f "(objectcategory=person)" > %USERPROFILE%\Desktop\adfind\ad_users.txt
-adfind.exe -f "objectcategory=computer" > %USERPROFILE%\Desktop\adfind\ad_computers.txt
-adfind.exe -sc trustdmp > %USERPROFILE%\Desktop\adfind\trustdmp.txt
-adfind.exe -subnets -f (objectCategory=subnet)> %USERPROFILE%\Desktop\adfind\subnets.txt
-adfind.exe -gcb -sc trustdmp > %USERPROFILE%\Desktop\adfind\trustdmp.txt
-adfind.exe -sc domainlist > %USERPROFILE%\Desktop\adfind\domainlist.txt
-adfind.exe -sc dcmodes > %USERPROFILE%\Desktop\adfind\dcmodes.txt
-adfind.exe -sc adinfo > %USERPROFILE%\Desktop\adfind\adinfo.txt
-adfind.exe -sc dclist > %USERPROFILE%\Desktop\adfind\dclist.txt
-adfind.exe -sc computers_pwdnotreqd > %USERPROFILE%\Desktop\adfind\computer_pwdnotereqd.txt
+%USERPROFILE%\Desktop\adfind\adfind.exe -f "(objectcategory=person)" > %USERPROFILE%\Desktop\adfind\ad_users.txt
+%USERPROFILE%\Desktop\adfind\adfind.exe -f "objectcategory=computer" > %USERPROFILE%\Desktop\adfind\ad_computers.txt
+%USERPROFILE%\Desktop\adfind\adfind.exe -sc trustdmp > %USERPROFILE%\Desktop\adfind\trustdmp.txt
+%USERPROFILE%\Desktop\adfind\adfind.exe -subnets -f (objectCategory=subnet)> %USERPROFILE%\Desktop\adfind\subnets.txt
+%USERPROFILE%\Desktop\adfind\adfind.exe -gcb -sc trustdmp > %USERPROFILE%\Desktop\adfind\trustdmp.txt
+%USERPROFILE%\Desktop\adfind\adfind.exe -sc domainlist > %USERPROFILE%\Desktop\adfind\domainlist.txt
+%USERPROFILE%\Desktop\adfind\adfind.exe -sc dcmodes > %USERPROFILE%\Desktop\adfind\dcmodes.txt
+%USERPROFILE%\Desktop\adfind\adfind.exe -sc adinfo > %USERPROFILE%\Desktop\adfind\adinfo.txt
+%USERPROFILE%\Desktop\adfind\adfind.exe -sc dclist > %USERPROFILE%\Desktop\adfind\dclist.txt
+%USERPROFILE%\Desktop\adfind\adfind.exe -sc computers_pwdnotreqd > %USERPROFILE%\Desktop\adfind\computer_pwdnotereqd.txt


### PR DESCRIPTION
When running this, I got a could not find adfind.exe error, which is due to not having the full file path and not being in the same directory to run it locally.